### PR TITLE
Fix start date validation

### DIFF
--- a/frontend/src/components/EventSearchForm.tsx
+++ b/frontend/src/components/EventSearchForm.tsx
@@ -88,8 +88,15 @@ export default function EventSearchForm() {
       return;
     }
 
-    const startDateTime = new Date().toISOString();
-    const endDateTime = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    if (!formData.startDateTime || !formData.endDateTime) {
+      setError('Please select a valid start and end date');
+      setIsLoading(false);
+      return;
+    }
+
+    // Use the user provided date range when searching
+    const startDateTime = new Date(formData.startDateTime).toISOString();
+    const endDateTime = new Date(formData.endDateTime).toISOString();
 
     try {
       const results = await searchEvents({ ...formData, startDateTime, endDateTime });


### PR DESCRIPTION
## Summary
- use the start and end date selected by the user
- ensure the dates are present before submitting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684867819fc4832aa4a12fc9d811da1e