### PR TITLE
Use vercel backend

### DIFF
--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,6 +1,9 @@
 import { EventSearchRequest, EventSearchResponse, ApiError } from '@/types/events';
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000';
+// Default to the deployed Vercel backend when no environment variable is set
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  'https://perplexity-events-backend.vercel.app';
 
 export async function searchEvents(params: EventSearchRequest): Promise<EventSearchResponse> {
   try {


### PR DESCRIPTION
## Summary
- point the frontend API client to the deployed Vercel backend

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend`

------
https://chatgpt.com/codex/tasks/task_e_6848b0745ec8832a81b74079e6025394