### PR TITLE
Fix today range start time

### DIFF
--- a/frontend/src/components/EventSearchForm.tsx
+++ b/frontend/src/components/EventSearchForm.tsx
@@ -293,8 +293,7 @@ export default function EventSearchForm() {
   };
 
   const setTodayRange = () => {
-    const start = new Date();
-    start.setHours(0, 0, 0, 0);
+    const start = new Date(Date.now() + 60 * 60 * 1000); // one hour from now
     const end = new Date();
     end.setHours(23, 59, 0, 0);
     const format = (d: Date) => d.toISOString().slice(0, 16);


### PR DESCRIPTION
## Summary
- start today's quick range one hour in the future

## Testing
- `npm test` in backend
- `npm test` in frontend *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848b4e83b04832ab8da55a0b4e10e02