### PR TITLE
Apply Apple design system

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,7 +17,8 @@
         "@mui/system": "^7.1.1",
         "next": "15.3.3",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "sf-pro": "^1.0.4"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -6060,6 +6061,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/sf-pro": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/sf-pro/-/sf-pro-1.0.4.tgz",
+      "integrity": "sha512-/YmhA4f+jJusBcEsbCgyeuhDD8VG9gVaMQuq8BKSyNMtfiTSlglpAEgjrDGBOZhMnubV+kr+0b8I1RejyffRRA==",
+      "license": "SIL OPEN FONT LICENSE",
+      "peerDependencies": {
+        "next": ">=15.3.0"
       }
     },
     "node_modules/sharp": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "@mui/system": "^7.1.1",
     "next": "15.3.3",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "sf-pro": "^1.0.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -32,7 +32,8 @@ html,
 body {
   max-width: 100vw;
   overflow-x: hidden;
-  font-family: 'Roboto', 'Helvetica', 'Arial', sans-serif;
+  font-family: 'SF Pro Text', 'SF Pro Display', -apple-system, BlinkMacSystemFont,
+    'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -7,6 +7,8 @@ import "@fontsource/roboto/300.css";
 import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
 import "@fontsource/roboto/700.css";
+import { SfProText } from 'sf-pro/text';
+import { SfProDisplay } from 'sf-pro/display';
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -20,8 +22,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body>
+    <html lang="en" className={`${SfProText.variable} ${SfProDisplay.variable}`}>
+      <body className={SfProText.className}>
         <AppRouterCacheProvider>
           <ThemeProvider theme={theme}>
             <CssBaseline />

--- a/frontend/src/app/theme.ts
+++ b/frontend/src/app/theme.ts
@@ -63,6 +63,8 @@ export const theme = createTheme({
   },
   typography: {
     fontFamily: [
+      '"SF Pro Text"',
+      '"SF Pro Display"',
       'Roboto',
       '-apple-system',
       'BlinkMacSystemFont',

--- a/frontend/src/components/EventCard.tsx
+++ b/frontend/src/components/EventCard.tsx
@@ -59,7 +59,7 @@ const EventCard: React.FC<EventCardProps> = ({ event }) => {
   };
 
   return (
-    <div className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow">
+    <div className="bg-white/70 backdrop-blur-lg border border-gray-200 rounded-2xl shadow-md p-6 hover:shadow-lg transition-shadow">
       {getVerificationBadge()}
       
       <h3 className="text-xl font-semibold mb-2">{event.name}</h3>


### PR DESCRIPTION
## Summary
- add `sf-pro` Apple fonts
- apply fonts in layout and theme
- update global CSS to use Apple fonts
- tweak event card styling for Apple-like appearance

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685635e8ab9c832ab520e1d1cc19c1f9